### PR TITLE
Fix the tube sorter desync problem

### DIFF
--- a/src/omaloon/world/blocks/distribution/TubeSorter.java
+++ b/src/omaloon/world/blocks/distribution/TubeSorter.java
@@ -121,7 +121,17 @@ public class TubeSorter extends Block{
 
         @Override
         public void buildConfiguration(Table table){
-            MultiItemSelection.buildTable(table, data);
+            MultiItemSelection.buildTable(
+                table,
+                content.items(),
+                data::isToggled,
+                item -> {
+                    data.toggle(item);
+                    int[] oldData = data.config();
+                    configure(null);
+                    configure(oldData);
+                }
+            );
         }
 
         @Override


### PR DESCRIPTION
As #68 states, the tube sorter does not sync because the config is not passed at all.

I keep the change minimal. Because `block.config` contains `toggle` inside, `configure` will trigger `toggle` so that `toggle` will trigger twice on the localhost, which is not intended. I chose to fully remove and re-toggle everything, but welcome to discuss and change accordingly.

It is definitely a solution to just toggle those new changes (but may incur more changes)