### PR TITLE
Replace reflection in pressure logic with an interface to improve performance

### DIFF
--- a/main/src/omaloon/world/GenericPressureBlock.java
+++ b/main/src/omaloon/world/GenericPressureBlock.java
@@ -11,47 +11,53 @@ import omaloon.world.modules.*;
 
 /**
  * A block class containing the necessary methods to support pressure,
- * it adds no new other functionality, so extend this instead of Block for a new block class.
+ * it adds no new other functionality, so extend this instead of Block for a new
+ * block class.
  */
-public class GenericPressureBlock extends Block{
+public class GenericPressureBlock extends Block implements PressureBlock {
     public PressureConfig pressureConfig = new PressureConfig();
 
-    public GenericPressureBlock(String name){
+    @Override
+    public PressureConfig pressureConfig() {
+        return pressureConfig;
+    }
+
+    public GenericPressureBlock(String name) {
         super(name);
         hasLiquids = true;
     }
 
     @Override
-    public void init(){
-        if(hasLiquids){
+    public void init() {
+        if (hasLiquids) {
             hasLiquids = false;
             pressureConfig.hasPressure = true;
         }
         super.init();
-        if(hasLiquids){
+        if (hasLiquids) {
             hasLiquids = false;
         }
     }
 
     @Override
-    public void setBars(){
+    public void setBars() {
         super.setBars();
         pressureConfig.addBars(this);
     }
 
     @Override
-    public void setStats(){
+    public void setStats() {
         super.setStats();
         pressureConfig.addStats(this, stats);
     }
 
-    public class GenericPressureBlockBuild extends Building implements HasPressure{
+    public class GenericPressureBlockBuild extends Building implements HasPressure {
         public PressureModule pressure;
 
         @Override
-        public Building create(Block block, Team team){
+        public Building create(Block block, Team team) {
             super.create(block, team);
-            if(pressureConfig().hasPressure){
+            if (pressureConfig().hasPressure) {
                 pressure = new PressureModule();
                 pressureGraph().addRaw(this);
             }
@@ -59,35 +65,35 @@ public class GenericPressureBlock extends Block{
         }
 
         @Override
-        public void onProximityUpdate(){
+        public void onProximityUpdate() {
             super.onProximityUpdate();
-            if(pressureConfig.hasPressure){
+            if (pressureConfig.hasPressure) {
                 new PressureGraph().floodMergeGraph(this);
             }
         }
 
         @Override
-        public PressureModule pressure(){
+        public PressureModule pressure() {
             return pressure;
         }
 
         @Override
-        public PressureConfig pressureConfig(){
+        public PressureConfig pressureConfig() {
             return pressureConfig;
         }
 
         @Override
-        public void read(Reads read, byte revision){
+        public void read(Reads read, byte revision) {
             super.read(read, revision);
-            if(pressureConfig.hasPressure){
+            if (pressureConfig.hasPressure) {
                 (pressure == null ? new PressureModule() : pressure).read(read);
             }
         }
 
         @Override
-        public void write(Writes write){
+        public void write(Writes write) {
             super.write(write);
-            if(pressureConfig.hasPressure){
+            if (pressureConfig.hasPressure) {
                 pressure.write(write);
             }
         }

--- a/main/src/omaloon/world/blocks/distribution/PressureLiquidConduit.java
+++ b/main/src/omaloon/world/blocks/distribution/PressureLiquidConduit.java
@@ -24,17 +24,17 @@ import omaloon.world.meta.PressureTank.*;
 import static mindustry.Vars.*;
 import static mindustry.type.Liquid.*;
 
-public class PressureLiquidConduit extends GenericPressureBlock implements ConnectedTile{
+public class PressureLiquidConduit extends GenericPressureBlock implements ConnectedTile {
     private static final Seq<BuildPlan> plansTmp = new Seq<>();
     public @Load(value = "@-bottom", fallBack = "@modname-liquid-bottom") TextureRegion bottomRegion;
-    public @Load(value = "@-#0$", lengths = {16}) TextureRegion[] topRegions;
+    public @Load(value = "@-#0$", lengths = { 16 }) TextureRegion[] topRegions;
     public TextureRegion[][] liquidRegions;
     public float liquidPadding = 3f;
     public float smoothAlphaSpeed = 0.014f;
     public @Nullable Block junctionReplacement;
     public @Nullable PressureLiquidBridge bridgeReplacement;
 
-    public PressureLiquidConduit(String name){
+    public PressureLiquidConduit(String name) {
         super(name);
         rotate = true;
         destructible = true;
@@ -45,65 +45,71 @@ public class PressureLiquidConduit extends GenericPressureBlock implements Conne
     }
 
     @Override
-    public boolean connectsTo(BuildPlan ref, BuildPlan other){
+    public boolean connectsTo(BuildPlan ref, BuildPlan other) {
         return facingEdge(ref, other, ref.rotation % 2) || facingEdge(ref, other, 2 + ref.rotation % 2);
     }
 
     @Override
-    public Block getReplacement(BuildPlan req, Seq<BuildPlan> plans){
-        if(junctionReplacement == null) return this;
+    public Block getReplacement(BuildPlan req, Seq<BuildPlan> plans) {
+        if (junctionReplacement == null)
+            return this;
 
-        Boolf<Point2> cont = p -> plans.contains(o -> o.x == req.x + p.x && o.y == req.y + p.y && (req.block instanceof PressureLiquidConduit || req.block instanceof PressureLiquidJunction));
+        Boolf<Point2> cont = p -> plans.contains(o -> o.x == req.x + p.x && o.y == req.y + p.y
+                && (req.block instanceof PressureLiquidConduit || req.block instanceof PressureLiquidJunction));
         return cont.get(Geometry.d4(req.rotation)) &&
-        cont.get(Geometry.d4(req.rotation - 2)) &&
-        req.tile() != null &&
-        req.tile().block() instanceof PressureLiquidConduit &&
-        Mathf.mod(req.build().rotation - req.rotation, 2) == 1 ? junctionReplacement : this;
+                cont.get(Geometry.d4(req.rotation - 2)) &&
+                req.tile() != null &&
+                req.tile().block() instanceof PressureLiquidConduit &&
+                Mathf.mod(req.build().rotation - req.rotation, 2) == 1 ? junctionReplacement : this;
     }
 
     @Override
-    protected TextureRegion[] icons(){
-        return new TextureRegion[]{
-        Core.atlas.find(name + "-bottom", "omaloon-liquid-bottom"),
-        Core.atlas.find(name + "-0")
+    protected TextureRegion[] icons() {
+        return new TextureRegion[] {
+                Core.atlas.find(name + "-bottom", "omaloon-liquid-bottom"),
+                Core.atlas.find(name + "-0")
         };
     }
 
     @Override
-    public void init(){
+    public void init() {
         pressureConfig.hasPressure = pressureConfig.acceptsPressure = pressureConfig.outputsPressure = true;
 
         super.init();
 
-        if(hasLiquids) hasLiquids = false;
-        if(junctionReplacement == null) junctionReplacement = OlDistributionBlocks.liquidJunction;
-        if(bridgeReplacement == null) bridgeReplacement = (PressureLiquidBridge)OlDistributionBlocks.liquidBridge;
+        if (hasLiquids)
+            hasLiquids = false;
+        if (junctionReplacement == null)
+            junctionReplacement = OlDistributionBlocks.liquidJunction;
+        if (bridgeReplacement == null)
+            bridgeReplacement = (PressureLiquidBridge) OlDistributionBlocks.liquidBridge;
 
-        if(pressureConfig.group == null) pressureConfig.group = TankGroup.transportation;
+        if (pressureConfig.group == null)
+            pressureConfig.group = TankGroup.transportation;
     }
 
     @Override
-    public void drawPlanRegion(BuildPlan plan, Eachable<BuildPlan> list){
+    public void drawPlanRegion(BuildPlan plan, Eachable<BuildPlan> list) {
         int tiling = mask(plan, list);
 
         Draw.rect(bottomRegion, plan.drawx(), plan.drawy(), 0);
-        if(tiling == 0){
+        if (tiling == 0) {
             Draw.rect(topRegions[tiling], plan.drawx(), plan.drawy(), (plan.rotation + 1) * 90f % 180 - 90);
-        }else{
+        } else {
             Draw.rect(topRegions[tiling], plan.drawx(), plan.drawy(), 0);
         }
     }
 
     @Override
-    public void load(){
+    public void load() {
         super.load();
 
         liquidRegions = new TextureRegion[2][animationFrames];
-        if(renderer != null){
+        if (renderer != null) {
             var frames = renderer.getFluidFrames();
 
-            for(int fluid = 0; fluid < 2; fluid++){
-                for(int frame = 0; frame < animationFrames; frame++){
+            for (int fluid = 0; fluid < 2; fluid++) {
+                for (int frame = 0; frame < animationFrames; frame++) {
                     TextureRegion base = frames[fluid][frame];
                     TextureRegion result = new TextureRegion();
                     result.set(base);
@@ -121,21 +127,22 @@ public class PressureLiquidConduit extends GenericPressureBlock implements Conne
 
     // TODO very expensive, redo
     @Override
-    public int mask(BuildPlan plan, Eachable<BuildPlan> list){
-        int[] tiling = {0};
+    public int mask(BuildPlan plan, Eachable<BuildPlan> list) {
+        int[] tiling = { 0 };
 
         list.each(next -> {
-            try{
-                if(
-                next.breaking ||
-                next == plan ||
-                !((PressureConfig)next.block.getClass().getField("pressureConfig").get(next.block)).hasPressure
-                ) return;
+            try {
+                if (next.breaking ||
+                        next == plan ||
+                        !(next.block instanceof PressureBlock p && p.pressureConfig().hasPressure))
+                    return;
                 int[] edge = facingEdges(plan, next);
-                if(edge.length == 0) return;
+                if (edge.length == 0)
+                    return;
 
-                if(!(next.block instanceof ConnectedTile a && !a.connectsTo(next, plan)) || connectsTo(plan, next)) tiling[0] |= (1 << edge[0]);
-            }catch(Exception ignored){
+                if (!(next.block instanceof ConnectedTile a && !a.connectsTo(next, plan)) || connectsTo(plan, next))
+                    tiling[0] |= (1 << edge[0]);
+            } catch (Exception ignored) {
             }
         });
 
@@ -143,46 +150,50 @@ public class PressureLiquidConduit extends GenericPressureBlock implements Conne
     }
 
     @Override
-    public void handlePlacementLine(Seq<BuildPlan> plans){
-        if(bridgeReplacement == null) return;
+    public void handlePlacementLine(Seq<BuildPlan> plans) {
+        if (bridgeReplacement == null)
+            return;
 
-        Boolf<BuildPlan> placeable = plan ->
-        (plan.placeable(player.team()) || (plan.tile() != null && plan.tile().block() == plan.block)) &&  //don't count the same block as inaccessible
-        !(plan != plans.first() && plan.build() != null && plan.build().rotation % 2 != plan.rotation % 2);
+        Boolf<BuildPlan> placeable = plan -> (plan.placeable(player.team())
+                || (plan.tile() != null && plan.tile().block() == plan.block)) && // don't count the same block as
+                                                                                  // inaccessible
+                !(plan != plans.first() && plan.build() != null && plan.build().rotation % 2 != plan.rotation % 2);
 
         plansTmp.clear();
 
-        for(int i = 0; i < plans.size; i++){
+        for (int i = 0; i < plans.size; i++) {
             BuildPlan plan = plans.get(i);
             BuildPlan next = null;
 
             plansTmp.add(plan);
 
-            if(!placeable.get(plan)) continue;
+            if (!placeable.get(plan))
+                continue;
 
             int oldI = i;
 
             int j = i + 1;
             boolean same = true;
-            while(j < plans.size){
-                if(placeable.get(plans.get(j))){
+            while (j < plans.size) {
+                if (placeable.get(plans.get(j))) {
                     next = plans.get(j);
                     i = j - 1;
                     break;
-                }else if(plans.get(j).tile() != null && plans.get(j).tile().block() != this){
+                } else if (plans.get(j).tile() != null && plans.get(j).tile().block() != this) {
                     same = false;
                 }
                 j++;
             }
 
-            if(next == null || plan.block != this || next.block != this) continue;
+            if (next == null || plan.block != this || next.block != this)
+                continue;
 
-            if(bridgeReplacement.linkValid(plan.tile(), next.tile()) && plan.dst(next) > 8 && !same){
+            if (bridgeReplacement.linkValid(plan.tile(), next.tile()) && plan.dst(next) > 8 && !same) {
                 plan.block = bridgeReplacement;
                 next.block = bridgeReplacement;
 
                 plan.config = new Point2(next.x - plan.x, next.y - plan.y);
-            }else{
+            } else {
                 i = oldI;
             }
         }
@@ -190,37 +201,36 @@ public class PressureLiquidConduit extends GenericPressureBlock implements Conne
         plans.set(plansTmp);
     }
 
-    public class PressureLiquidConduitBuild extends GenericPressureBlockBuild{
+    public class PressureLiquidConduitBuild extends GenericPressureBlockBuild {
         public int tiling = 0;
         public float smoothAlpha;
 
         @Override
-        public boolean acceptsFluid(HasPressure from, @Nullable Liquid liquid, float amount){
-            return
-            super.acceptsFluid(from, liquid, amount) &&
-            (liquid == pressure.getMain() || liquid == null || pressure.getMain() == null || from.pressure().getMain() == null || FluidInteraction.interactions.contains(i -> i.canInteract(pressure.getMain(), liquid)));
+        public boolean acceptsFluid(HasPressure from, @Nullable Liquid liquid, float amount) {
+            return super.acceptsFluid(from, liquid, amount) &&
+                    (liquid == pressure.getMain() || liquid == null || pressure.getMain() == null
+                            || from.pressure().getMain() == null
+                            || FluidInteraction.interactions.contains(i -> i.canInteract(pressure.getMain(), liquid)));
         }
 
         @Override
-        public boolean connects(HasPressure to){
-            return
-            super.connects(to) &&
-            (
-            !(to instanceof PressureLiquidConduitBuild) ||
-            to == front() || to == back() ||
-            this == to.toBuilding().front() || this == to.toBuilding().back() ||
-            !proximity.contains(to.toBuilding())
-            );
+        public boolean connects(HasPressure to) {
+            return super.connects(to) &&
+                    (!(to instanceof PressureLiquidConduitBuild) ||
+                            to == front() || to == back() ||
+                            this == to.toBuilding().front() || this == to.toBuilding().back() ||
+                            !proximity.contains(to.toBuilding()));
         }
 
         @Override
-        public void draw(){
+        public void draw() {
             Draw.rect(bottomRegion, x, y);
             Liquid main = pressure.getMain();
 
-            smoothAlpha = Mathf.approachDelta(smoothAlpha, main == null ? 0f : getFluid(main) / (getFluid(main) + Math.abs(getFluid(null))), smoothAlphaSpeed);
+            smoothAlpha = Mathf.approachDelta(smoothAlpha,
+                    main == null ? 0f : getFluid(main) / (getFluid(main) + Math.abs(getFluid(null))), smoothAlphaSpeed);
 
-            if(smoothAlpha > 0.001f && main != null){
+            if (smoothAlpha > 0.001f && main != null) {
                 int frame = main.getAnimationFrame();
                 int gas = main.gas ? 1 : 0;
 
@@ -233,24 +243,25 @@ public class PressureLiquidConduit extends GenericPressureBlock implements Conne
         }
 
         @Override
-        public void onPressureGraphUpdate(){
+        public void onPressureGraphUpdate() {
             tiling = 0;
-            for(int i = 0; i < 4; i++){
-                HasPressure build = nearby(i) instanceof HasPressure ? ((HasPressure)nearby(i)).getFluidDestination(this, null) : null;
-                if(
-                build != null && HasPressure.connects(this, build)
-                ) tiling |= (1 << i);
+            for (int i = 0; i < 4; i++) {
+                HasPressure build = nearby(i) instanceof HasPressure
+                        ? ((HasPressure) nearby(i)).getFluidDestination(this, null)
+                        : null;
+                if (build != null && HasPressure.connects(this, build))
+                    tiling |= (1 << i);
             }
         }
 
         @Override
-        public void read(Reads read, byte revision){
+        public void read(Reads read, byte revision) {
             super.read(read, revision);
             smoothAlpha = read.f();
         }
 
         @Override
-        public void write(Writes write){
+        public void write(Writes write) {
             super.write(write);
             write.f(smoothAlpha);
         }

--- a/main/src/omaloon/world/blocks/distribution/PressureLiquidPump.java
+++ b/main/src/omaloon/world/blocks/distribution/PressureLiquidPump.java
@@ -21,7 +21,7 @@ import omaloon.world.meta.PressureTank.*;
 import static mindustry.Vars.renderer;
 import static mindustry.type.Liquid.animationFrames;
 
-public class PressureLiquidPump extends GenericPressureBlock implements ConnectedTile{
+public class PressureLiquidPump extends GenericPressureBlock implements ConnectedTile {
     public float pumpStrength = 0.1f;
 
     public float pressureDifference = 10;
@@ -34,12 +34,12 @@ public class PressureLiquidPump extends GenericPressureBlock implements Connecte
     public Effect pumpEffectIn = OlFx.pumpIn;
 
     public TextureRegion[][] liquidRegions;
-    public @Load(value = "@-#0$", lengths = {4}) TextureRegion[] tiles;
+    public @Load(value = "@-#0$", lengths = { 4 }) TextureRegion[] tiles;
     public @Load(value = "@-top") TextureRegion topRegion;
     public @Load(value = "@-bottom", fallBack = "omaloon-liquid-bottom") TextureRegion bottomRegion;
     public @Load("@-arrow") TextureRegion arrowRegion;
 
-    public PressureLiquidPump(String name){
+    public PressureLiquidPump(String name) {
         super(name);
         rotate = true;
         destructible = true;
@@ -48,19 +48,19 @@ public class PressureLiquidPump extends GenericPressureBlock implements Connecte
     }
 
     @Override
-    public boolean connectsTo(BuildPlan ref, BuildPlan other){
+    public boolean connectsTo(BuildPlan ref, BuildPlan other) {
         return (facingEdge(ref, other, ref.rotation % 2) || facingEdge(ref, other, 2 + ref.rotation % 2)) &&
-        !(other.block instanceof PressureLiquidPump && other.rotation != ref.rotation);
+                !(other.block instanceof PressureLiquidPump && other.rotation != ref.rotation);
     }
 
     @Override
-    public void drawPlanRegion(BuildPlan plan, Eachable<BuildPlan> list){
+    public void drawPlanRegion(BuildPlan plan, Eachable<BuildPlan> list) {
         int tiling = mask(plan, list);
 
-        if(tiling == 0){
+        if (tiling == 0) {
             Draw.rect(tiles[0], plan.drawx(), plan.drawy(), ((1 + plan.rotation) % 2 - 1) * 90f);
             Draw.rect(topRegion, plan.drawx(), plan.drawy(), plan.rotation * 90f);
-        }else{
+        } else {
             Draw.rect(bottomRegion, plan.drawx(), plan.drawy());
             Draw.rect(arrowRegion, plan.drawx(), plan.drawy(), plan.rotation * 90f);
             Draw.rect(tiles[tiling], plan.drawx(), plan.drawy(), ((1 + plan.rotation) % 2 - 1) * 90f);
@@ -68,15 +68,15 @@ public class PressureLiquidPump extends GenericPressureBlock implements Connecte
     }
 
     @Override
-    public TextureRegion[] icons(){
-        return new TextureRegion[]{
-        Core.atlas.find(name + "-0"),
-        Core.atlas.find(name + "-top")
+    public TextureRegion[] icons() {
+        return new TextureRegion[] {
+                Core.atlas.find(name + "-0"),
+                Core.atlas.find(name + "-top")
         };
     }
 
     @Override
-    public void init(){
+    public void init() {
         pressureConfig.hasPressure = true;
         pressureConfig.acceptsPressure = pressureConfig.outputsPressure = false;
 
@@ -86,15 +86,15 @@ public class PressureLiquidPump extends GenericPressureBlock implements Connecte
     }
 
     @Override
-    public void load(){
+    public void load() {
         super.load();
 
         liquidRegions = new TextureRegion[2][animationFrames];
-        if(renderer != null){
+        if (renderer != null) {
             var frames = renderer.getFluidFrames();
 
-            for(int fluid = 0; fluid < 2; fluid++){
-                for(int frame = 0; frame < animationFrames; frame++){
+            for (int fluid = 0; fluid < 2; fluid++) {
+                for (int frame = 0; frame < animationFrames; frame++) {
                     TextureRegion base = frames[fluid][frame];
                     TextureRegion result = new TextureRegion();
                     result.set(base);
@@ -111,24 +111,24 @@ public class PressureLiquidPump extends GenericPressureBlock implements Connecte
     }
 
     @Override
-    public int mask(BuildPlan plan, Eachable<BuildPlan> list){
-        int[] tiling = {0};
+    public int mask(BuildPlan plan, Eachable<BuildPlan> list) {
+        int[] tiling = { 0 };
 
         list.each(next -> {
-            try{
-                if(
-                next.breaking ||
-                next == plan ||
-                !((PressureConfig)next.block.getClass().getField("pressureConfig").get(next.block)).hasPressure
-                ) return;
+            try {
+                if (next.breaking ||
+                        next == plan ||
+                        !(next.block instanceof PressureBlock p && p.pressureConfig().hasPressure))
+                    return;
 
-                if(!(next.block instanceof ConnectedTile a && !a.connectsTo(next, plan)) || connectsTo(plan, next)){
-                    if(facingEdge(plan, next, Mathf.mod((1 + plan.rotation) % 2 - 1, 4))){
+                if (!(next.block instanceof ConnectedTile a && !a.connectsTo(next, plan)) || connectsTo(plan, next)) {
+                    if (facingEdge(plan, next, Mathf.mod((1 + plan.rotation) % 2 - 1, 4))) {
                         tiling[0] |= 1;
-                    }else if(facingEdge(plan, next, Mathf.mod((1 + plan.rotation) % 2 - 1 + 2, 4))) tiling[0] |= 2;
-//                    }else tiling[0] |= 2;
+                    } else if (facingEdge(plan, next, Mathf.mod((1 + plan.rotation) % 2 - 1 + 2, 4)))
+                        tiling[0] |= 2;
+                    // }else tiling[0] |= 2;
                 }
-            }catch(Exception ignored){
+            } catch (Exception ignored) {
             }
         });
 
@@ -136,20 +136,20 @@ public class PressureLiquidPump extends GenericPressureBlock implements Connecte
     }
 
     @Override
-    public void setBars(){
+    public void setBars() {
         super.setBars();
         removeBar("omaloon-fluid-bar");
     }
 
     @Override
-    public void setStats(){
+    public void setStats() {
         super.setStats();
         stats.remove(Stat.liquidCapacity);
         stats.add(OlStats.pumpStrength, pumpStrength * 60f, StatUnit.liquidSecond);
         stats.add(OlStats.pressureGradient, OlStats.number(pressureDifference, OlStats.pressureUnit, false));
     }
 
-    public class PressureLiquidPumpBuild extends GenericPressureBlockBuild{
+    public class PressureLiquidPumpBuild extends GenericPressureBlockBuild {
         public float effectTimer;
         public int tiling;
         public float smoothAlpha;
@@ -157,52 +157,49 @@ public class PressureLiquidPump extends GenericPressureBlock implements Connecte
         public boolean functioning;
 
         @Override
-        public boolean acceptsFluid(HasPressure from, @Nullable Liquid liquid, float amount){
+        public boolean acceptsFluid(HasPressure from, @Nullable Liquid liquid, float amount) {
             return false;
         }
 
         @Override
-        public float ambientVolume(){
+        public float ambientVolume() {
             return 1f / chainSize();
         }
 
         /**
          * Returns the length of the pump chain
          */
-        public int chainSize(){
+        public int chainSize() {
             return pressure.section.builds.size;
         }
 
         @Override
-        public boolean connects(HasPressure to){
-            return
-            super.connects(to) &&
-            (
-            front() == to || back() == to ||
-            !proximity.contains(to.toBuilding())
-            ) &&
-            (
-            !(to instanceof PressureLiquidPumpBuild pump) ||
-            pump.rotation == rotation
-            );
+        public boolean connects(HasPressure to) {
+            return super.connects(to) &&
+                    (front() == to || back() == to ||
+                            !proximity.contains(to.toBuilding()))
+                    &&
+                    (!(to instanceof PressureLiquidPumpBuild pump) ||
+                            pump.rotation == rotation);
         }
 
         @Override
-        public void draw(){
+        public void draw() {
             Draw.rect(bottomRegion, x, y);
-            if(tiling != 0){
+            if (tiling != 0) {
                 HasPressure front = getTo();
                 HasPressure back = getFrom();
 
-                @Nullable Liquid frontLiquid = front != null && front.pressure() != null ? front.pressure().getMain() : null;
-                @Nullable Liquid backLiquid = back != null && back.pressure() != null ? back.pressure().getMain() : null;
-                @Nullable Liquid pumpLiquid = backLiquid != null ? backLiquid : frontLiquid;
+                @Nullable
+                Liquid frontLiquid = front != null && front.pressure() != null ? front.pressure().getMain() : null;
+                @Nullable
+                Liquid backLiquid = back != null && back.pressure() != null ? back.pressure().getMain() : null;
+                @Nullable
+                Liquid pumpLiquid = backLiquid != null ? backLiquid : frontLiquid;
 
                 Color drawColor = Tmp.c1.set(
-                frontLiquid == null ? Color.clear : frontLiquid.color
-                ).lerp(
-                backLiquid == null ? Color.clear : backLiquid.color, 0.5f
-                );
+                        frontLiquid == null ? Color.clear : frontLiquid.color).lerp(
+                                backLiquid == null ? Color.clear : backLiquid.color, 0.5f);
 
                 float alpha = 0;
                 alpha += frontLiquid != null ? 0.5f : 0f;
@@ -210,7 +207,7 @@ public class PressureLiquidPump extends GenericPressureBlock implements Connecte
 
                 smoothAlpha = Mathf.approachDelta(smoothAlpha, alpha, smoothAlphaSpeed);
 
-                if(pumpLiquid != null){
+                if (pumpLiquid != null) {
                     Draw.color(drawColor, smoothAlpha);
                     Draw.rect(liquidRegions[Mathf.num(pumpLiquid.gas)][pumpLiquid.getAnimationFrame()], x, y);
                     Draw.color();
@@ -219,21 +216,24 @@ public class PressureLiquidPump extends GenericPressureBlock implements Connecte
                 Draw.rect(arrowRegion, x, y, rotdeg());
             }
 
-            if(rotation == 1 || rotation == 2) Draw.yscl = -1f;
+            if (rotation == 1 || rotation == 2)
+                Draw.yscl = -1f;
             Draw.rect(tiles[tiling], x, y, rotdeg());
             Draw.yscl = 1f;
 
-            if(tiling == 0) Draw.rect(topRegion, x, y, rotdeg());
+            if (tiling == 0)
+                Draw.rect(topRegion, x, y, rotdeg());
         }
 
         /**
          * Returns the building at the start of the pump chain.
          */
-        public @Nullable HasPressure getFrom(){
+        public @Nullable HasPressure getFrom() {
             PressureLiquidPumpBuild last = this;
             HasPressure out = back() instanceof HasPressure back ? back.getFluidDestination(last, null) : null;
-            while(out instanceof PressureLiquidPumpBuild pump){
-                if(!HasPressure.connects(pump, last)) return null;
+            while (out instanceof PressureLiquidPumpBuild pump) {
+                if (!HasPressure.connects(pump, last))
+                    return null;
                 last = pump;
                 out = pump.back() instanceof HasPressure back ? back.getFluidDestination(last, null) : null;
             }
@@ -243,11 +243,12 @@ public class PressureLiquidPump extends GenericPressureBlock implements Connecte
         /**
          * Returns the building at the end of the pump chain.
          */
-        public @Nullable HasPressure getTo(){
+        public @Nullable HasPressure getTo() {
             PressureLiquidPumpBuild last = this;
             HasPressure out = front() instanceof HasPressure front ? front.getFluidDestination(last, null) : null;
-            while(out instanceof PressureLiquidPumpBuild pump){
-                if(!HasPressure.connects(pump, last)) return null;
+            while (out instanceof PressureLiquidPumpBuild pump) {
+                if (!HasPressure.connects(pump, last))
+                    return null;
                 last = pump;
                 out = pump.front() instanceof HasPressure front ? front.getFluidDestination(last, null) : null;
             }
@@ -255,72 +256,84 @@ public class PressureLiquidPump extends GenericPressureBlock implements Connecte
         }
 
         @Override
-        public void onPressureGraphUpdate(){
+        public void onPressureGraphUpdate() {
             tiling = 0;
-            if(front() instanceof HasPressure front && HasPressure.connects(this, front.getFluidDestination(this, null))) tiling |= 1;
-            if(back() instanceof HasPressure back && HasPressure.connects(this, back.getFluidDestination(this, null))) tiling |= 2;
+            if (front() instanceof HasPressure front
+                    && HasPressure.connects(this, front.getFluidDestination(this, null)))
+                tiling |= 1;
+            if (back() instanceof HasPressure back && HasPressure.connects(this, back.getFluidDestination(this, null)))
+                tiling |= 2;
         }
 
         @Override
-        public boolean outputsFluid(HasPressure to, @Nullable Liquid liquid, float amount){
+        public boolean outputsFluid(HasPressure to, @Nullable Liquid liquid, float amount) {
             return false;
         }
 
         @Override
-        public void read(Reads read, byte revision){
+        public void read(Reads read, byte revision) {
             super.read(read, revision);
             smoothAlpha = read.f();
         }
 
         @Override
-        public boolean shouldAmbientSound(){
+        public boolean shouldAmbientSound() {
             return functioning;
         }
 
         @Override
-        public void updateTile(){
-            if(efficiency > 0){
+        public void updateTile() {
+            if (efficiency > 0) {
                 HasPressure front = getTo();
                 HasPressure back = getFrom();
 
-                @Nullable Liquid pumpLiquid = (back == null ? null : back.pressure().getMain());
+                @Nullable
+                Liquid pumpLiquid = (back == null ? null : back.pressure().getMain());
 
                 float frontPressure = front == null ? 0 : front.getPressure(pumpLiquid);
                 float backPressure = back == null ? 0 : back.getPressure(pumpLiquid);
 
                 float maxFlow = Physics.fluidFlow(
-                backPressure + pressureDifference * chainSize(),
-                back == null ? 8 : back.pressureConfig().fluidCapacity,
-                frontPressure,
-                front == null ? 8 : front.pressureConfig().fluidCapacity,
-                OlLiquids.getDensity(pumpLiquid),
-                1, 1
-                );
+                        backPressure + pressureDifference * chainSize(),
+                        back == null ? 8 : back.pressureConfig().fluidCapacity,
+                        frontPressure,
+                        front == null ? 8 : front.pressureConfig().fluidCapacity,
+                        OlLiquids.getDensity(pumpLiquid),
+                        1, 1);
 
-                if(back != null){
+                if (back != null) {
                     pressure.pressures[0] = back.getPressure(pumpLiquid);
-                }else pressure.pressures[0] = 0;
-                if(front != null){
+                } else
+                    pressure.pressures[0] = 0;
+                if (front != null) {
                     pressure.pressures[0] += front.getPressure(pumpLiquid);
                 }
                 pressure.pressures[0] /= 2f;
 
                 float flow = Mathf.clamp(
-                (maxFlow > 0 ? pumpStrength : -pumpStrength) / chainSize() * Time.delta,
-                -Math.abs(maxFlow),
-                Math.abs(maxFlow)
-                );
+                        (maxFlow > 0 ? pumpStrength : -pumpStrength) / chainSize() * Time.delta,
+                        -Math.abs(maxFlow),
+                        Math.abs(maxFlow));
 
-                if(effectTimer >= effectInterval && !Mathf.zero(flow, 0.001f)){
-                    if(flow < 0){
-                        if(pumpLiquid == null || (front != null && front.getFluid(pumpLiquid) > 0.001f)){
-                            if(back == null && !(back() instanceof PressureLiquidPumpBuild p && p.rotation == rotation)) pumpEffectOut.at(x, y, rotdeg() + 180f, pumpLiquid == null ? Color.white : pumpLiquid.color);
-                            if(front == null && !(front() instanceof PressureLiquidPumpBuild p && p.rotation == rotation)) pumpEffectIn.at(x, y, rotdeg(), Color.white);
+                if (effectTimer >= effectInterval && !Mathf.zero(flow, 0.001f)) {
+                    if (flow < 0) {
+                        if (pumpLiquid == null || (front != null && front.getFluid(pumpLiquid) > 0.001f)) {
+                            if (back == null
+                                    && !(back() instanceof PressureLiquidPumpBuild p && p.rotation == rotation))
+                                pumpEffectOut.at(x, y, rotdeg() + 180f,
+                                        pumpLiquid == null ? Color.white : pumpLiquid.color);
+                            if (front == null
+                                    && !(front() instanceof PressureLiquidPumpBuild p && p.rotation == rotation))
+                                pumpEffectIn.at(x, y, rotdeg(), Color.white);
                         }
-                    }else{
-                        if(pumpLiquid == null || (back != null && back.getFluid(pumpLiquid) > 0.001f)){
-                            if(back == null && !(back() instanceof PressureLiquidPumpBuild p && p.rotation == rotation)) pumpEffectIn.at(x, y, rotdeg() + 180f, Color.white);
-                            if(front == null && !(front() instanceof PressureLiquidPumpBuild p && p.rotation == rotation)) pumpEffectOut.at(x, y, rotdeg(), pumpLiquid == null ? Color.white : pumpLiquid.color);
+                    } else {
+                        if (pumpLiquid == null || (back != null && back.getFluid(pumpLiquid) > 0.001f)) {
+                            if (back == null
+                                    && !(back() instanceof PressureLiquidPumpBuild p && p.rotation == rotation))
+                                pumpEffectIn.at(x, y, rotdeg() + 180f, Color.white);
+                            if (front == null
+                                    && !(front() instanceof PressureLiquidPumpBuild p && p.rotation == rotation))
+                                pumpEffectOut.at(x, y, rotdeg(), pumpLiquid == null ? Color.white : pumpLiquid.color);
                         }
                     }
                     effectTimer %= 1;
@@ -328,24 +341,24 @@ public class PressureLiquidPump extends GenericPressureBlock implements Connecte
 
                 functioning = !Mathf.zero(flow, 0.001f);
 
-                if(
-                front == null || back == null ||
-                (front.acceptsFluid(back, pumpLiquid, flow) &&
-                back.outputsFluid(front, pumpLiquid, flow))
-                ){
+                if (front == null || back == null ||
+                        (front.acceptsFluid(back, pumpLiquid, flow) &&
+                                back.outputsFluid(front, pumpLiquid, flow))) {
                     effectTimer += edelta();
-                    if(front != null){
+                    if (front != null) {
                         front.addFluid(pumpLiquid, flow);
-                    }else if(pumpLiquid != null && flow > 0) Puddles.deposit(tile.nearby(rotation), tile, pumpLiquid, flow);
-                    if(back != null){
+                    } else if (pumpLiquid != null && flow > 0)
+                        Puddles.deposit(tile.nearby(rotation), tile, pumpLiquid, flow);
+                    if (back != null) {
                         back.removeFluid(pumpLiquid, flow);
-                    }else if(pumpLiquid != null && flow < 0) Puddles.deposit(tile.nearby((rotation + 2) % 4), tile, pumpLiquid, -flow);
+                    } else if (pumpLiquid != null && flow < 0)
+                        Puddles.deposit(tile.nearby((rotation + 2) % 4), tile, pumpLiquid, -flow);
                 }
             }
         }
 
         @Override
-        public void write(Writes write){
+        public void write(Writes write) {
             super.write(write);
             write.f(smoothAlpha);
         }

--- a/main/src/omaloon/world/blocks/production/PressureCrafter.java
+++ b/main/src/omaloon/world/blocks/production/PressureCrafter.java
@@ -17,80 +17,87 @@ import omaloon.world.interfaces.*;
 import omaloon.world.meta.*;
 import omaloon.world.modules.*;
 
-public class PressureCrafter extends GenericCrafter{
+public class PressureCrafter extends GenericCrafter implements PressureBlock {
     public PressureConfig pressureConfig = new PressureConfig();
+
+    @Override
+    public PressureConfig pressureConfig() {
+        return pressureConfig;
+    }
 
     public boolean useConsumerMultiplier = true;
 
     public float outputAir;
 
-    public PressureCrafter(String name){
+    public PressureCrafter(String name) {
         super(name);
     }
 
     @Override
-    public void init(){
+    public void init() {
         super.init();
 
-        if(hasLiquids){
+        if (hasLiquids) {
             hasLiquids = false;
             pressureConfig.hasPressure = true;
         }
     }
 
     @Override
-    public void setBars(){
+    public void setBars() {
         super.setBars();
         pressureConfig.addBars(this);
 
-        if(outputLiquids != null && outputLiquids.length > 0){
+        if (outputLiquids != null && outputLiquids.length > 0) {
             removeBar("omaloon-fluid-bar");
 
-            for(var stack : outputLiquids){
+            for (var stack : outputLiquids) {
                 addBar("omaloon-fluid-bar-" + stack.liquid.name, build -> {
-                    HasPressure e = (HasPressure)build;
+                    HasPressure e = (HasPressure) build;
                     Liquid liq = stack.liquid;
                     return new Bar(
-                    () -> liq == null ?
-                    Core.bundle.format("bar.omaloon-air-bar", OlStats.formatValue(e.getFluid(liq), 2, false)) :
-                    Core.bundle.format("bar.omaloon-fluid-bar", liq.localizedName, OlStats.formatValue(e.getFluid(liq), 2, false), OlStats.formatValue(e.getFluid(null), 2, false)),
-                    () -> liq == null ? Color.white : liq.color,
-                    () -> liq == null ? 0f : e.getFluid(liq) / Math.max(1f, Math.abs(e.getFluid(null)))
-                    );
+                            () -> liq == null
+                                    ? Core.bundle.format("bar.omaloon-air-bar",
+                                            OlStats.formatValue(e.getFluid(liq), 2, false))
+                                    : Core.bundle.format("bar.omaloon-fluid-bar", liq.localizedName,
+                                            OlStats.formatValue(e.getFluid(liq), 2, false),
+                                            OlStats.formatValue(e.getFluid(null), 2, false)),
+                            () -> liq == null ? Color.white : liq.color,
+                            () -> liq == null ? 0f : e.getFluid(liq) / Math.max(1f, Math.abs(e.getFluid(null))));
                 });
             }
 
-            if(outputAir > 0){
+            if (outputAir > 0) {
                 addBar("omaloon-fluid-bar-air", build -> {
-                    HasPressure e = (HasPressure)build;
+                    HasPressure e = (HasPressure) build;
                     Liquid liq = null;
                     return new Bar(
-                    () -> Core.bundle.format("bar.omaloon-air-bar", OlStats.formatValue(e.getFluid(liq), 2, false)),
-                    () -> Color.white,
-                    () -> 0f
-                    );
+                            () -> Core.bundle.format("bar.omaloon-air-bar",
+                                    OlStats.formatValue(e.getFluid(liq), 2, false)),
+                            () -> Color.white,
+                            () -> 0f);
                 });
             }
         }
     }
 
     @Override
-    public void setStats(){
+    public void setStats() {
         super.setStats();
         pressureConfig.addStats(this, stats);
 
-        if(outputAir > 0){
+        if (outputAir > 0) {
             stats.add(Stat.output, OlStats.fluid(null, outputAir, 1f, true));
         }
     }
 
-    public class PressureCrafterBuild extends GenericCrafterBuild implements HasPressure{
+    public class PressureCrafterBuild extends GenericCrafterBuild implements HasPressure {
         public PressureModule pressure;
 
         @Override
-        public Building create(Block block, Team team){
+        public Building create(Block block, Team team) {
             super.create(block, team);
-            if(pressureConfig().hasPressure){
+            if (pressureConfig().hasPressure) {
                 pressure = new PressureModule();
                 pressureGraph().addRaw(this);
             }
@@ -98,119 +105,124 @@ public class PressureCrafter extends GenericCrafter{
         }
 
         @Override
-        public void dumpOutputs(){
-            if(outputItems != null && timer(timerDump, dumpTime / timeScale)){
-                for(ItemStack output : outputItems){
+        public void dumpOutputs() {
+            if (outputItems != null && timer(timerDump, dumpTime / timeScale)) {
+                for (ItemStack output : outputItems) {
                     dump(output.item);
                 }
             }
         }
 
-        public float efficiencyMultiplier(){
+        public float efficiencyMultiplier() {
             float val = 1;
-            if(!useConsumerMultiplier) return val;
-            for(Consume consumer : consumers){
+            if (!useConsumerMultiplier)
+                return val;
+            for (Consume consumer : consumers) {
                 val *= consumer.efficiencyMultiplier(this);
             }
             return val;
         }
 
         @Override
-        public float efficiencyScale(){
+        public float efficiencyScale() {
             return super.efficiencyScale() * efficiencyMultiplier();
         }
 
         @Override
-        public void onProximityUpdate(){
+        public void onProximityUpdate() {
             super.onProximityUpdate();
-            if(pressureConfig.hasPressure){
+            if (pressureConfig.hasPressure) {
                 new PressureGraph().floodMergeGraph(this);
             }
         }
 
         @Override
-        public PressureModule pressure(){
+        public PressureModule pressure() {
             return pressure;
         }
 
         @Override
-        public PressureConfig pressureConfig(){
+        public PressureConfig pressureConfig() {
             return pressureConfig;
         }
 
         @Override
-        public void read(Reads read, byte revision){
+        public void read(Reads read, byte revision) {
             super.read(read, revision);
-            if(pressureConfig.hasPressure){
+            if (pressureConfig.hasPressure) {
                 (pressure == null ? new PressureModule() : pressure).read(read);
             }
         }
 
         @Override
-        public boolean shouldConsume(){
-            if(outputItems != null){
-                for(var output : outputItems){
-                    if(items.get(output.item) + output.amount > itemCapacity){
+        public boolean shouldConsume() {
+            if (outputItems != null) {
+                for (var output : outputItems) {
+                    if (items.get(output.item) + output.amount > itemCapacity) {
                         return false;
                     }
                 }
             }
 
-            if(outputLiquids != null && !ignoreLiquidFullness){
+            if (outputLiquids != null && !ignoreLiquidFullness) {
                 boolean allFull = true;
                 boolean someFull = false;
 
-                if(getFluid(null) >= pressureConfig.fluidCapacity){
+                if (getFluid(null) >= pressureConfig.fluidCapacity) {
                     someFull = true;
-                }else{
+                } else {
                     allFull = false;
                 }
 
-                for(LiquidStack output : outputLiquids){
-                    if(getFluid(output.liquid) >= pressureConfig.fluidCapacity){
+                for (LiquidStack output : outputLiquids) {
+                    if (getFluid(output.liquid) >= pressureConfig.fluidCapacity) {
                         someFull = true;
-                    }else{
+                    } else {
                         allFull = false;
                     }
                 }
 
-                if(allFull || (someFull && !ignoreLiquidFullness)) return false;
+                if (allFull || (someFull && !ignoreLiquidFullness))
+                    return false;
             }
             return enabled;
         }
 
         @Override
-        public void updateTile(){
-            if(efficiency > 0){
+        public void updateTile() {
+            if (efficiency > 0) {
                 progress += getProgressIncrease(craftTime);
                 warmup = Mathf.approachDelta(warmup, warmupTarget(), warmupSpeed);
 
-                //continuously output based on efficiency, uncapped
+                // continuously output based on efficiency, uncapped
                 float inc = getProgressIncrease(1f);
-                if(outputLiquids != null){
-                    for(var output : outputLiquids) addFluid(output.liquid, output.amount * inc);
+                if (outputLiquids != null) {
+                    for (var output : outputLiquids)
+                        addFluid(output.liquid, output.amount * inc);
                 }
-                if(outputAir > 0) addFluid(null, outputAir * inc);
+                if (outputAir > 0)
+                    addFluid(null, outputAir * inc);
 
-                if(wasVisible && Mathf.chanceDelta(updateEffectChance)){
-                    updateEffect.at(x + Mathf.range(size * updateEffectSpread), y + Mathf.range(size * updateEffectSpread));
+                if (wasVisible && Mathf.chanceDelta(updateEffectChance)) {
+                    updateEffect.at(x + Mathf.range(size * updateEffectSpread),
+                            y + Mathf.range(size * updateEffectSpread));
                 }
-            }else{
+            } else {
                 warmup = Mathf.approachDelta(warmup, 0f, warmupSpeed);
             }
 
             totalProgress += warmup * edelta();
 
-            if(progress >= 1f){
+            if (progress >= 1f) {
                 craft();
             }
             dumpOutputs();
         }
 
         @Override
-        public void write(Writes write){
+        public void write(Writes write) {
             super.write(write);
-            if(pressureConfig.hasPressure){
+            if (pressureConfig.hasPressure) {
                 pressure.write(write);
             }
         }

--- a/main/src/omaloon/world/blocks/production/PressureDrill.java
+++ b/main/src/omaloon/world/blocks/production/PressureDrill.java
@@ -12,103 +12,111 @@ import omaloon.world.meta.*;
 import omaloon.world.meta.PressureTank.*;
 import omaloon.world.modules.*;
 
-public class PressureDrill extends Drill{
+public class PressureDrill extends Drill implements PressureBlock {
     public PressureConfig pressureConfig = new PressureConfig();
+
+    @Override
+    public PressureConfig pressureConfig() {
+        return pressureConfig;
+    }
 
     public boolean useConsumerMultiplier = true;
 
-    public PressureDrill(String name){
+    public PressureDrill(String name) {
         super(name);
     }
 
     @Override
-    public void init(){
-        if(hasLiquids){
+    public void init() {
+        if (hasLiquids) {
             hasLiquids = false;
             pressureConfig.hasPressure = true;
         }
 
         super.init();
 
-        if(hasLiquids) hasLiquids = false;
+        if (hasLiquids)
+            hasLiquids = false;
 
-        if(pressureConfig.group == null) pressureConfig.group = TankGroup.drills;
+        if (pressureConfig.group == null)
+            pressureConfig.group = TankGroup.drills;
     }
 
     @Override
-    public void setBars(){
+    public void setBars() {
         super.setBars();
         pressureConfig.addBars(this);
     }
 
     @Override
-    public void setStats(){
+    public void setStats() {
         super.setStats();
         pressureConfig.addStats(this, stats);
     }
 
-    public class PressureDrillBuild extends DrillBuild implements HasPressure{
+    public class PressureDrillBuild extends DrillBuild implements HasPressure {
         public PressureModule pressure;
 
         @Override
-        public Building create(Block block, Team team){
+        public Building create(Block block, Team team) {
             super.create(block, team);
-            if(pressureConfig().hasPressure){
+            if (pressureConfig().hasPressure) {
                 pressure = new PressureModule();
                 pressureGraph().addRaw(this);
             }
             return this;
         }
 
-        public float efficiencyMultiplier(){
+        public float efficiencyMultiplier() {
             float val = 1;
-            if(!useConsumerMultiplier) return val;
-            for(Consume consumer : consumers){
+            if (!useConsumerMultiplier)
+                return val;
+            for (Consume consumer : consumers) {
                 val *= consumer.efficiencyMultiplier(this);
             }
             return val;
         }
 
         @Override
-        public float efficiencyScale(){
+        public float efficiencyScale() {
             return super.efficiencyScale() * efficiencyMultiplier();
         }
 
         @Override
-        public float getProgressIncrease(float baseTime){
+        public float getProgressIncrease(float baseTime) {
             return super.getProgressIncrease(baseTime) * efficiencyMultiplier();
         }
 
         @Override
-        public void onProximityUpdate(){
+        public void onProximityUpdate() {
             super.onProximityUpdate();
-            if(pressureConfig.hasPressure){
+            if (pressureConfig.hasPressure) {
                 new PressureGraph().floodMergeGraph(this);
             }
         }
 
         @Override
-        public PressureModule pressure(){
+        public PressureModule pressure() {
             return pressure;
         }
 
         @Override
-        public PressureConfig pressureConfig(){
+        public PressureConfig pressureConfig() {
             return pressureConfig;
         }
 
         @Override
-        public void read(Reads read, byte revision){
+        public void read(Reads read, byte revision) {
             super.read(read, revision);
-            if(pressureConfig.hasPressure){
+            if (pressureConfig.hasPressure) {
                 (pressure == null ? new PressureModule() : pressure).read(read);
             }
         }
 
         @Override
-        public void write(Writes write){
+        public void write(Writes write) {
             super.write(write);
-            if(pressureConfig.hasPressure){
+            if (pressureConfig.hasPressure) {
                 pressure.write(write);
             }
         }

--- a/main/src/omaloon/world/interfaces/PressureBlock.java
+++ b/main/src/omaloon/world/interfaces/PressureBlock.java
@@ -1,0 +1,7 @@
+package omaloon.world.interfaces;
+
+import omaloon.world.meta.*;
+
+public interface PressureBlock {
+    PressureConfig pressureConfig();
+}


### PR DESCRIPTION
I noticed several liquid blocks were using reflection to access pressureConfig during tile masking, which can get pretty slow in larger factories. I've introduced a simple PressureBlock interface to standardize this. This change replaces those reflection calls with direct interface methods in conduits and pumps, making the pressure system logic much more efficient without changing any gameplay behavior.