### PR TITLE
Replace reflection in pressure logic with an interface to improve performance

### DIFF
--- a/main/src/omaloon/world/GenericPressureBlock.java
+++ b/main/src/omaloon/world/GenericPressureBlock.java
@@ -13,8 +13,13 @@ import omaloon.world.modules.*;
  * A block class containing the necessary methods to support pressure,
  * it adds no new other functionality, so extend this instead of Block for a new block class.
  */
-public class GenericPressureBlock extends Block{
+public class GenericPressureBlock extends Block implements PressureBlock{
     public PressureConfig pressureConfig = new PressureConfig();
+
+    @Override
+    public PressureConfig pressureConfig(){
+        return pressureConfig;
+    }
 
     public GenericPressureBlock(String name){
         super(name);

--- a/main/src/omaloon/world/blocks/distribution/PressureLiquidConduit.java
+++ b/main/src/omaloon/world/blocks/distribution/PressureLiquidConduit.java
@@ -129,7 +129,7 @@ public class PressureLiquidConduit extends GenericPressureBlock implements Conne
                 if(
                 next.breaking ||
                 next == plan ||
-                !((PressureConfig)next.block.getClass().getField("pressureConfig").get(next.block)).hasPressure
+                !(next.block instanceof PressureBlock && ((PressureBlock)next.block).pressureConfig().hasPressure)
                 ) return;
                 int[] edge = facingEdges(plan, next);
                 if(edge.length == 0) return;

--- a/main/src/omaloon/world/blocks/distribution/PressureLiquidPump.java
+++ b/main/src/omaloon/world/blocks/distribution/PressureLiquidPump.java
@@ -119,7 +119,7 @@ public class PressureLiquidPump extends GenericPressureBlock implements Connecte
                 if(
                 next.breaking ||
                 next == plan ||
-                !((PressureConfig)next.block.getClass().getField("pressureConfig").get(next.block)).hasPressure
+                !(next.block instanceof PressureBlock && ((PressureBlock)next.block).pressureConfig().hasPressure)
                 ) return;
 
                 if(!(next.block instanceof ConnectedTile a && !a.connectsTo(next, plan)) || connectsTo(plan, next)){

--- a/main/src/omaloon/world/blocks/production/PressureCrafter.java
+++ b/main/src/omaloon/world/blocks/production/PressureCrafter.java
@@ -17,8 +17,13 @@ import omaloon.world.interfaces.*;
 import omaloon.world.meta.*;
 import omaloon.world.modules.*;
 
-public class PressureCrafter extends GenericCrafter{
+public class PressureCrafter extends GenericCrafter implements PressureBlock{
     public PressureConfig pressureConfig = new PressureConfig();
+
+    @Override
+    public PressureConfig pressureConfig(){
+        return pressureConfig;
+    }
 
     public boolean useConsumerMultiplier = true;
 

--- a/main/src/omaloon/world/blocks/production/PressureDrill.java
+++ b/main/src/omaloon/world/blocks/production/PressureDrill.java
@@ -12,8 +12,13 @@ import omaloon.world.meta.*;
 import omaloon.world.meta.PressureTank.*;
 import omaloon.world.modules.*;
 
-public class PressureDrill extends Drill{
+public class PressureDrill extends Drill implements PressureBlock{
     public PressureConfig pressureConfig = new PressureConfig();
+
+    @Override
+    public PressureConfig pressureConfig(){
+        return pressureConfig;
+    }
 
     public boolean useConsumerMultiplier = true;
 

--- a/main/src/omaloon/world/interfaces/PressureBlock.java
+++ b/main/src/omaloon/world/interfaces/PressureBlock.java
@@ -1,0 +1,7 @@
+package omaloon.world.interfaces;
+
+import omaloon.world.meta.*;
+
+public interface PressureBlock{
+    PressureConfig pressureConfig();
+}


### PR DESCRIPTION
I noticed several liquid blocks were using reflection to access pressureConfig during tile masking, which can get pretty slow in larger factories. I've introduced a simple PressureBlock interface to standardize this. This change replaces those reflection calls with direct interface methods in conduits and pumps, making the pressure system logic much more efficient without changing any gameplay behavior.

My apologies for the mess in the previous PR where I accidentally included some global formatting changes. I've completely reset and cleaned up those files to strictly follow the project's original formatting and style guidelines this time.