### PR TITLE
Refactor TubeRouter item interpolation

### DIFF
--- a/main/src/omaloon/world/blocks/distribution/TubeRouter.java
+++ b/main/src/omaloon/world/blocks/distribution/TubeRouter.java
@@ -21,6 +21,11 @@ public class TubeRouter extends Router{
     public @Load("@-rotator") TextureRegion rotatorRegion;
     public @Load(value = "@-side#0$", lengths = {2}) TextureRegion[] sideRegion;
 
+    public static final Interp itemInterp = t -> {
+        float s = 2f * t - 1f;
+        return 0.7f * s * s + 0.3f;
+    };
+
     public TubeRouter(String name){
         super(name);
         rotate = true;
@@ -76,11 +81,7 @@ public class TubeRouter extends Router{
                 int turn = Mathf.mod(relativeTo(target) + 1 - relativeTo(lastInput), 4) - 1;
 
                 rot = turn * 90f * Mathf.clamp(time);
-
-                // TODO make a proper Interp for this
-                float h = 0.3f;
-                float c = 2f;
-                float d = (1f - h) * Mathf.pow(2f * Mathf.clamp(time) - 1f, c) + h;
+                float d = itemInterp.apply(Mathf.clamp(time));
 
                 Draw.rect(
                 lastItem.uiIcon,


### PR DESCRIPTION
I noticed there was a TODO in TubeRouter about making a proper interpolation for item movement. I've refactored the drawing logic to use a static Interp field instead of calculating the math manually inside the draw method. This makes the code a bit cleaner and more efficient by avoiding pow calculations every frame while keeping the exact same visual behavior.

Note: I didn't notice any weird behavior during my testing after this change, but I can't guarantee it's 100% flawless, mostly because I'm not entirely sure how Mindustry handles this specific interpolation under the hood. Let me know if this approach makes sense or if it needs adjusting!