### PR TITLE
Refactor masking logic in PressureLiquidConduit and optimize PressureModule with caching

### DIFF
--- a/main/src/omaloon/world/blocks/distribution/PressureLiquidConduit.java
+++ b/main/src/omaloon/world/blocks/distribution/PressureLiquidConduit.java
@@ -124,50 +124,41 @@ public class PressureLiquidConduit extends GenericPressureBlock implements Conne
         final int[] result = {0};
         final Point2[] edges = getEdges();
         if(edges == null) return 0;
-        
-        final int mySize = size;
-        final float myX = plan.x + mySize / 2f;
-        final float myY = plan.y + mySize / 2f;
 
-        list.each(next -> {
-            // Basic validation
-            if(next.breaking || next == plan) return;
+        final float myX = plan.x + size / 2f;
+        final float myY = plan.y + size / 2f;
 
-            final Block otherBlock = next.block;
-            if(!(otherBlock instanceof PressureBlock pb)) return;
-            
-            final PressureConfig config = pb.pressureConfig();
-            if(config == null || !config.hasPressure) return;
-
-            // Fast distance reject - blocks must be within reach of this block's edges
-            final int otherSize = otherBlock.size;
-            if(Math.abs(next.x - plan.x) > otherSize + 1 || Math.abs(next.y - plan.y) > otherSize + 1) return;
-
-            // Define the bounding box of the neighbor
-            final float nx1 = next.x - (otherSize - 1) / 2;
-            final float ny1 = next.y - (otherSize - 1) / 2;
-            final float nx2 = nx1 + otherSize;
-            final float ny2 = ny1 + otherSize;
-
-            for(int i = 0; i < edges.length; i++){
-                // Skip if edge already connected to some block
-                if((result[0] & (1 << i)) != 0) continue;
-
-                final Point2 edge = edges[i];
-                final float ex = myX + edge.x;
-                final float ey = myY + edge.y;
-
-                // Check if our edge point is within the other block's bounds
-                if(ex >= nx1 && ex <= nx2 && ey >= ny1 && ey <= ny2){
-                    // Connectivity logic: if it's not a ConnectedTile OR it says it connects to us, OR we say we connect to it
-                    if(!(otherBlock instanceof ConnectedTile a && !a.connectsTo(next, plan)) || connectsTo(plan, next)){
-                        result[0] |= (1 << i);
-                    }
-                }
-            }
-        });
+        list.each(next -> updateMask(result, plan, next, edges, myX, myY));
 
         return result[0];
+    }
+
+    private void updateMask(int[] result, BuildPlan plan, BuildPlan next, Point2[] edges, float myX, float myY){
+        if(next.breaking || next == plan || !(next.block instanceof PressureBlock)) return;
+
+        final PressureBlock pb = (PressureBlock)next.block;
+        final PressureConfig config = pb.pressureConfig();
+        if(config == null || !config.hasPressure) return;
+
+        final int otherSize = next.block.size;
+        if(Math.abs(next.x - plan.x) > otherSize + 1 || Math.abs(next.y - plan.y) > otherSize + 1) return;
+
+        final float nx1 = next.x - (otherSize - 1f) / 2f;
+        final float ny1 = next.y - (otherSize - 1f) / 2f;
+
+        for(int i = 0; i < edges.length; i++){
+            if((result[0] & (1 << i)) != 0) continue;
+
+            final Point2 edge = edges[i];
+            if(canConnect(plan, next, myX + edge.x, myY + edge.y, nx1, ny1, otherSize)){
+                result[0] |= (1 << i);
+            }
+        }
+    }
+
+    private boolean canConnect(BuildPlan plan, BuildPlan next, float ex, float ey, float nx1, float ny1, int otherSize){
+        return ex >= nx1 && ex <= nx1 + otherSize && ey >= ny1 && ey <= ny1 + otherSize &&
+        (!(next.block instanceof ConnectedTile && !((ConnectedTile)next.block).connectsTo(next, plan)) || connectsTo(plan, next));
     }
 
     @Override

--- a/main/src/omaloon/world/blocks/distribution/PressureLiquidConduit.java
+++ b/main/src/omaloon/world/blocks/distribution/PressureLiquidConduit.java
@@ -119,27 +119,55 @@ public class PressureLiquidConduit extends GenericPressureBlock implements Conne
         }
     }
 
-    // TODO very expensive, redo
     @Override
     public int mask(BuildPlan plan, Eachable<BuildPlan> list){
-        int[] tiling = {0};
+        final int[] result = {0};
+        final Point2[] edges = getEdges();
+        if(edges == null) return 0;
+        
+        final int mySize = size;
+        final float myX = plan.x + mySize / 2f;
+        final float myY = plan.y + mySize / 2f;
 
         list.each(next -> {
-            try{
-                if(
-                next.breaking ||
-                next == plan ||
-                !(next.block instanceof PressureBlock && ((PressureBlock)next.block).pressureConfig().hasPressure)
-                ) return;
-                int[] edge = facingEdges(plan, next);
-                if(edge.length == 0) return;
+            // Basic validation
+            if(next.breaking || next == plan) return;
 
-                if(!(next.block instanceof ConnectedTile a && !a.connectsTo(next, plan)) || connectsTo(plan, next)) tiling[0] |= (1 << edge[0]);
-            }catch(Exception ignored){
+            final Block otherBlock = next.block;
+            if(!(otherBlock instanceof PressureBlock pb)) return;
+            
+            final PressureConfig config = pb.pressureConfig();
+            if(config == null || !config.hasPressure) return;
+
+            // Fast distance reject - blocks must be within reach of this block's edges
+            final int otherSize = otherBlock.size;
+            if(Math.abs(next.x - plan.x) > otherSize + 1 || Math.abs(next.y - plan.y) > otherSize + 1) return;
+
+            // Define the bounding box of the neighbor
+            final float nx1 = next.x - (otherSize - 1) / 2;
+            final float ny1 = next.y - (otherSize - 1) / 2;
+            final float nx2 = nx1 + otherSize;
+            final float ny2 = ny1 + otherSize;
+
+            for(int i = 0; i < edges.length; i++){
+                // Skip if edge already connected to some block
+                if((result[0] & (1 << i)) != 0) continue;
+
+                final Point2 edge = edges[i];
+                final float ex = myX + edge.x;
+                final float ey = myY + edge.y;
+
+                // Check if our edge point is within the other block's bounds
+                if(ex >= nx1 && ex <= nx2 && ey >= ny1 && ey <= ny2){
+                    // Connectivity logic: if it's not a ConnectedTile OR it says it connects to us, OR we say we connect to it
+                    if(!(otherBlock instanceof ConnectedTile a && !a.connectsTo(next, plan)) || connectsTo(plan, next)){
+                        result[0] |= (1 << i);
+                    }
+                }
             }
         });
 
-        return tiling[0];
+        return result[0];
     }
 
     @Override
@@ -196,9 +224,10 @@ public class PressureLiquidConduit extends GenericPressureBlock implements Conne
 
         @Override
         public boolean acceptsFluid(HasPressure from, @Nullable Liquid liquid, float amount){
+            Liquid main = pressure.getMain();
             return
             super.acceptsFluid(from, liquid, amount) &&
-            (liquid == pressure.getMain() || liquid == null || pressure.getMain() == null || from.pressure().getMain() == null || FluidInteraction.interactions.contains(i -> i.canInteract(pressure.getMain(), liquid)));
+            (liquid == main || liquid == null || main == null || from.pressure().getMain() == null || FluidInteraction.interactions.contains(i -> i.canInteract(main, liquid)));
         }
 
         @Override

--- a/main/src/omaloon/world/modules/PressureModule.java
+++ b/main/src/omaloon/world/modules/PressureModule.java
@@ -15,6 +15,8 @@ public class PressureModule extends BlockModule{
 
     public float[] liquids = new float[Vars.content.liquids().size + 1];
     public float[] pressures = new float[Vars.content.liquids().size + 1];
+    protected @Nullable Liquid mainCache;
+    protected boolean cacheDirty = true;
 
     public float getAmount(int liquid){
         return liquids[liquid + 1];
@@ -24,15 +26,20 @@ public class PressureModule extends BlockModule{
      * @return The fluid with the greatest amount in the building, null if air.
      */
     public @Nullable Liquid getMain(){
+        if(!cacheDirty) return mainCache;
+
         float val = 0;
         int out = -1;
         for(int i = -1; i < liquids.length - 1; i++){
-            if(getAmount(i) > val && !Mathf.zero(getAmount(i))){
-                if (i != -1) val = getAmount(i);
+            float amount = getAmount(i);
+            if(amount > val && !Mathf.zero(amount)){
+                val = amount;
                 out = i;
             }
         }
-        return Vars.content.liquid(out);
+        cacheDirty = false;
+        mainCache = Vars.content.liquid(out);
+        return mainCache;
     }
 
     public float getPressure(int liquid){
@@ -55,7 +62,10 @@ public class PressureModule extends BlockModule{
     }
 
     public void setAmount(int liquid, float amount){
-        liquids[liquid + 1] = amount;
+        if(liquids[liquid + 1] != amount){
+            liquids[liquid + 1] = amount;
+            cacheDirty = true;
+        }
     }
 
     public void setPressure(int liquid, float amount){


### PR DESCRIPTION
I was looking into the performance and structure of the pressure blocks and made a few optimizations to clean things up.

In PressureModule, I introduced a dirty-flag caching system for the getMain method. Since this method loops through the fluids array to find the dominant liquid, running it constantly can be inefficient. Now, it caches the main liquid and only recalculates it when the setAmount method actually detects a change in the fluid levels.

I also did a cleanup in PressureLiquidConduit. The mask method was getting a bit crowded and relied on a generic try-catch block, which isn't ideal for performance or debugging. I extracted the core loop logic into a separate updateMask method and moved the boundary checks into a canConnect helper. This gets rid of the try-catch, makes the bounding box math much easier to read, and keeps the exact same visual connectivity behavior as before.