### PR TITLE
Add Spanish localization

### DIFF
--- a/main/assets/bundles/bundle_es.properties
+++ b/main/assets/bundles/bundle_es.properties
@@ -1,0 +1,333 @@
+## ui
+dialog.omaloon-disclaimer.title = AVISO
+dialog.omaloon-disclaimer = \
+  Omaloon aún se encuentra en desarrollo [accent]alfa[] y puede contener algunos errores.\
+  \nEl contenido presentado aquí no es final y puede estar sujeto a cambios radicales en futuras versiones.\
+  \nNo te encariñes con tus partidas guardadas con Omaloon activado, ya que cada nueva versión las borrará.
+button.omaloon-show-disclaimer = No volver a mostrar
+
+dialog.omaloon-updater.title = ¡Nueva versión de Omaloon encontrada!
+dialog.omaloon-updater = \
+  Lo más probable es que Omaloon haya recibido una actualización de contenido o una corrección de errores. Se recomienda instalar la actualización.\
+  \n[red]¡Todas tus partidas con Omaloon activado se borrarán después de actualizar![]\
+  \n\n[gray]La versión actual de Omaloon es v{0}, pero la última es v{1}.[]
+button.omaloon-ignore = Ignorar
+button.omaloon-updater-show-changes = Lista de Cambios
+button.omaloon-install-update = ¿Instalar y reiniciar ahora?
+
+## techtree
+techtree.omaloon-glasmore = Glasmore
+
+## settings
+settings.omaloon = Configuración de Omaloon
+
+setting.omaloon-shelter-opacity.name = Opacidad del Refugio
+setting.omaloon-loading-screen.name = Pantalla de Carga Personalizada
+setting.omaloon-loading-screen.description = Cuando está activado, Omaloon reemplazará la pantalla de carga original por una personalizada.
+setting.omaloon-show-disclaimer.name = Ocultar Aviso
+setting.omaloon-check-updates.name = Buscar Actualizaciones
+setting.omaloon-check-updates.description = [red]ROTO PARA VERSIONES INDEV[]\nCuando está activado, Omaloon buscará actualizaciones al iniciar.
+setting.omaloon-override-stats.name = Sobrescribir Estadísticas
+setting.omaloon-override-stats.description = Cuando está activado, se cambian algunas estadísticas originales. [red] Desactívalo cuando uses otros mods.[]\nRequiere reiniciar para aplicar los cambios.
+setting.omaloon-developer-mode.name = Modo Desarrollador
+setting.omaloon-developer-mode.description = Activa ciertas funciones de depuración, como acceso por consola a las clases del mod.\nRequiere el mod [accent]Context[] para funcionar correctamente.\nRequiere reiniciar para aplicar los cambios.
+setting.omaloon-reset-hints = Restablecer Consejos del Mod
+setting.omaloon-discord-join.name = ¡Únete al servidor de Discord de Omaloon!
+
+## Hints
+hint.omaloon-air = A diferencia del \uEAB2 [accent]Tubo de Fluido[], ciertos bloques con mayor capacidad pueden almacenar más fluido a la misma presión.
+hint.omaloon-drills = Los bloques que utilizan presión alcanzan su máxima eficiencia en valores extremos. El \uEAA8 [accent]Taladro de Impacto[] destaca en condiciones cercanas al vacío, mientras que otros bloques pueden requerir alta presión.
+hint.omaloon-pump_chaining = Las bombas pueden apilarse en serie o en paralelo. Lo primero permite mayor fuerza, lo segundo permite mayor eficiencia.
+hint.omaloon-wind_turbines = Las \uEAAB [accent]Turbinas Eólicas[] generan una fuerte turbulencia, dañándose entre sí si se colocan demasiado cerca. Para evitar su destrucción, la colocación está restringida a una distancia segura.
+hint.omaloon-press = Algunos bloques, como la \uEAAD [accent]Prensa de Compuesto[], no intercambian fluido con los vecinos, interactuando solo con bloques de transporte como el \uEAB2 [accent]Tubo de Fluido[].
+hint.omaloon-shelter = El \uEAA6 [accent]Refugio Pequeño[] utiliza presión positiva, extendiendo su rango efectivo a medida que aumenta la presión.
+
+## Sector
+
+sector.omaloon-the-crater.name = El Cráter
+sector.omaloon-the-crater.description = Un cráter ecuatorial de tamaño medio, uno de los muchos dejados por los fragmentos de Set. Un lugar tranquilo y discreto, libre de actividad enemiga e ideal para un primer aterrizaje. Explora los recursos disponibles y ten cuidado: el frío extremo trae un clima peligroso.
+
+tc.cobalt = :omaloon-cobalt: El [#bbc7c9]Cobalto[] es un recurso central para la\nmayor parte de la tecnología aquí. Minálo para automatizar tu base.
+tc.research-drill = Abre el árbol tecnológico :tree:.\nInvestiga el :omaloon-hammer-drill: [accent]Taladro de Impacto[].
+tc.rotate-distributor = :omaloon-tube-distributor: Los [accent]Distribuidores de Tubo[] no aceptan ítems\npor el lado marcado. Gira el bloque para que no mire\nhacia el :omaloon-hammer-drill: [accent]Taladro de Impacto[].
+tc.rotate-block = [accent]Gira el bloque hacia el otro lado[]
+tc.pump = Coloca una :omaloon-liquid-pump: [accent]Bomba Mecánica[] mirando\nhacia afuera de el :omaloon-hammer-drill: [accent]Taladro de Impacto[] para\n darle energía.
+tc.nickel = :omaloon-nickel: El [#699B87]Níquel[] es un recurso vital,\nnecesario para estructuras y tecnología avanzadas.
+tc.build-shelters = Parece que se acerca una tormenta de granizo masiva.\nInvestiga el :omaloon-small-shelter: [accent]Refugio Pequeño[]\ny cubre todos tus edificios contra el granizo.
+tc.hail-timer = La tormenta de granizo llega en {0}
+tc.press = Mientras ruge la tormenta, asegura que tu base esté\nprotegida, luego configura la producción de :omaloon-composite: [#485674]Compuesto[].
+tc.build-press = Construye una :omaloon-composite-press: [accent]Prensa de Compuesto[].\nEl :omaloon-composite: [#485674]Compuesto[] es esencial\npara escapar de este cráter y seguir progresando.
+tc.core = Es hora de partir. Mejora el Núcleo.
+
+## planets
+planet.omaloon-omaloon.name = Omaloon
+planet.omaloon-glasmore.name = Glasmore
+
+## weather
+database-category.weather = Climas
+weather.omaloon-hail-storm.name = Tormenta de Granizo
+weather.omaloon-hail-storm.description = Patrón climático común en los cráteres de Glasmore: lluvia de glacium y piedras de granizo de varios tamaños. Peligroso para estructuras y unidades sin refugio.
+weather.omaloon-aghanite-storm.name = Tormenta de Polvo
+weather.omaloon-aghanite-storm.description = Patrón climático común en los desiertos de Glasmore: nubes de polvo masivas que se mueven a velocidades capaces de levantar rocas por el aire. Peligroso para estructuras y unidades sin refugio.
+
+## items
+item.omaloon-cobalt.name = Cobalto
+item.omaloon-cobalt.description = Se utiliza en muchos tipos de construcción y munición.
+
+item.omaloon-nickel.name = Níquel
+item.omaloon-nickel.description = Esencial para electrónica básica y sistemas basados en energía.
+
+item.omaloon-composite.name = Compuesto
+item.omaloon-composite.description = Ampliamente utilizado como endurecedor simple.
+
+item.omaloon-magnetite.name = Magnetita
+
+## environment
+block.omaloon-cliff.name = Acantilado
+block.omaloon-cliff-helper.name = Ayuda de Acantilado
+
+block.omaloon-glasmore-metal.name = Metal de Glasmore
+block.omaloon-glasmore-metal-plus.name = Metal de Glasmore Plus
+block.omaloon-glasmore-metal-don.name = Metal de Glasmore Dona
+
+block.omaloon-gerb-remains.name = Restos de Gerb
+
+block.omaloon-ruined-tiles.name = Baldosas Arruinadas
+block.omaloon-ruined-masonry.name = Albañilería Arruinada
+block.omaloon-ruined-wall.name = Muro Arruinado
+
+block.omaloon-dead-shrub.name = Arbusto Muerto
+block.omaloon-spiked-tree.name = Árbol de Espinas Muerto
+block.omaloon-bush-tree.name = Arbusto de Árbol Muerto
+
+block.omaloon-fallen-dead-tree.name = Árbol Muerto Caído
+block.omaloon-fallen-dead-tree-bottom-half.name = Mitad Inferior de Árbol Muerto Caído
+block.omaloon-fallen-dead-tree-top-half.name = Mitad Superior de Árbol Muerto Caído
+block.omaloon-standing-dead-tree.name = Árbol Muerto
+block.omaloon-dead-tree-stump.name = Tocón Muerto
+
+block.omaloon-dead-grass.name = Hierba Muerta
+
+block.omaloon-frozen-soil.name = Suelo Congelado
+block.omaloon-frozen-soil-boulder.name = Roca de Suelo Congelado
+block.omaloon-frozen-soil-wall.name = Muro de Suelo Congelado
+
+block.omaloon-alabaster.name = Alabastro
+block.omaloon-alabaster-tiles.name = Baldosas de Alabastro
+block.omaloon-alabaster-craters.name = Cráter de Alabastro
+block.omaloon-alabaster-craters-large.name = Cráter de Alabastro Grande
+block.omaloon-alabaster-wall.name = Muro de Alabastro
+block.omaloon-alabaster-boulder.name = Roca de Alabastro
+
+block.omaloon-smooth-aghanite.name = Aghanita Suave
+block.omaloon-cracked-aghanite.name = Aghanita Agrietada
+block.omaloon-pebbled-aghanite.name = Aghanita Pedregosa
+block.omaloon-sandy-aghanite.name = Aghanita Arenosa
+block.omaloon-aghanite.name = Aghanita
+block.omaloon-aghanite-wall.name = Muro de Aghanita
+block.omaloon-aghanite-crag.name = Risco de Aghanita
+block.omaloon-aghanite-boulder.name = Roca de Aghanita
+
+block.omaloon-gray-aghanite.name = Aghanita Gris
+block.omaloon-smooth-gray-aghanite.name = Aghanita Gris Suave
+block.omaloon-gray-aghanite-wall.name = Muro de Aghanita Gris
+block.omaloon-gray-aghanite-crag.name = Risco de Aghanita Gris
+block.omaloon-gray-aghanite-boulder.name = Roca de Aghanita Gris
+
+block.omaloon-smooth-white-aghanite.name = Aghanita Blanca Suave
+block.omaloon-weathered-white-aghanite.name = Aghanita Blanca Desgastada
+block.omaloon-white-aghanite.name = Aghanita Blanca
+block.omaloon-white-aghanite-dust.name = Polvo de Aghanita Blanca
+block.omaloon-white-aghanite-wall.name = Muro de Aghanita Blanca
+block.omaloon-white-aghanite-boulder.name = Roca de Aghanita Blanca
+
+block.omaloon-verdant-aghanite.name = Aghanita Verdosa
+block.omaloon-verdant-aghanite-wall.name = Muro de Aghanita Verdosa
+block.omaloon-verdant-aghanite-boulder.name = Roca de Aghanita Verdosa
+
+block.omaloon-deep-glacium.name = Glacium Profundo
+block.omaloon-grenite-glacium.name = Glacium de Grenita
+block.omaloon-shallow-glacium.name = Glacium
+
+block.omaloon-coastal-grenite.name = Grenita Costera
+block.omaloon-grenite.name = Grenita
+block.omaloon-grenite-wall.name = Muro de Grenita
+block.omaloon-dark-grenite-wall.name = Muro de Grenita Oscura
+block.omaloon-grenite-boulder.name = Roca de Grenita
+
+block.omaloon-blue-ice.name = Hielo Azul
+block.omaloon-blue-ice-pieces.name = Trozos de Hielo Azul
+block.omaloon-weathered-ice.name = Hielo Desgastado
+block.omaloon-blue-ice-wall.name = Muro de Hielo Azul
+block.omaloon-weathered-ice-wall.name = Muro de Hielo Desgastado
+
+block.omaloon-blue-snow.name = Nieve Azul
+block.omaloon-blue-snowdrifts.name = Ventisqueros de Nieve Azul
+block.omaloon-blue-snow-wall.name = Muro de Nieve Azul
+block.omaloon-blue-boulder.name = Roca Azul
+
+## liquids
+liquid.omaloon-glacium.name = Glacium
+liquid.omaloon-tired-glacium.name = Glacium Agotado
+
+air = Aire
+
+## status
+status.omaloon-glacied.name = Glaciado
+status.omaloon-wind-breeze.name = Brisa
+
+status.omaloon-filled-with-glacium.name = Lleno de Glacium
+status.omaloon-filled-with-oil.name = Lleno de Petróleo
+status.omaloon-filled-with-slag.name = Lleno de Escoria
+status.omaloon-filled-with-water.name = Lleno de Agua
+
+## bars
+bar.omaloon-air-bar = Aire: {0}
+bar.omaloon-fluid-bar = {0}: {1} | Aire: {2}
+bar.omaloon-pressure-bar = Presión: {0}
+
+## stats
+category.omaloon-pressure = Presión
+
+stat.omaloon-space = Área Mínima
+
+stat.omaloon-debris = Partículas
+
+stat.omaloon-density = Densidad
+
+stat.omaloon-min-pressure = Presión Mínima
+stat.omaloon-max-pressure = Presión Máxima
+
+stat.omaloon-pump-strength = Fuerza de Bomba
+stat.omaloon-pressure-gradient = Gradiente de Presión
+
+unit.omaloon-blocks-cubed = Bloques³
+unit.omaloon-density-unit = Unidades de Líquido / Bloques³
+unit.omaloon-viscosity-unit = Unidades de Presión por Segundo
+unit.omaloon-pressure-unit = Unidades de Presión
+
+unit.omaloon-percent-per-second = % / Segundo
+
+## storage
+block.omaloon-landing-capsule.name = Cápsula de Aterrizaje
+block.omaloon-landing-capsule.description = Núcleo barato de la base. Requiere combustible para el lanzamiento.
+block.omaloon-core-floe.name = Núcleo: Floe
+block.omaloon-core-floe.description = Núcleo de la base. No requiere combustible para el lanzamiento.
+
+## distribution
+block.omaloon-tube-conveyor.name = Transportador de Tubo
+block.omaloon-tube-conveyor.description = Mueve ítems hacia adelante. No puede acceder a la mayoría de los edificios.
+
+block.omaloon-tube-distributor.name = Distribuidor de Tubo
+block.omaloon-tube-distributor.description = Distribuye ítems de entrada a 3 salidas por igual. Se utiliza comúnmente para distribuir ítems entre edificios y transportadores de tubo. No acepta ítems por uno de sus lados.
+
+block.omaloon-tube-junction.name = Unión de Tubo
+block.omaloon-tube-junction.description = Actúa como un puente para dos transportadores de tubo que se cruan.
+
+block.omaloon-tube-bridge-conveyor.name = Puente de Tubo
+block.omaloon-tube-bridge-conveyor.description = Transporta ítems sobre terreno o edificios.
+
+block.omaloon-tube-sorter.name = Clasificador de Tubo
+block.omaloon-tube-sorter.description = Filtra múltiples ítems, y si un ítem de entrada coincide con la selección, pasa adelante. De lo contrario, el ítem sale por la izquierda y la derecha.
+
+block.omaloon-tube-overflow-gate.name = Puerta de Desbordamiento de Tubo
+block.omaloon-tube-overflow-gate.description = Solo envía ítems a la izquierda y derecha si el camino frontal está bloqueado.
+
+block.omaloon-tube-underflow-gate.name = Puerta de Flujo Inferior de Tubo
+block.omaloon-tube-underflow-gate.description = Lo opuesto a una puerta de desbordamiento. Envía ítems al frente si los caminos de izquierda y derecha están bloqueados.
+
+block.omaloon-liquid-tube.name = Tubo de Líquido
+block.omaloon-liquid-tube.description = Mueve líquidos.
+
+block.omaloon-liquid-pump.name = Bomba Mecánica
+block.omaloon-liquid-pump.description = Mueve líquidos hacia adelante.
+
+block.omaloon-liquid-outlet.name = Salida de Líquido
+block.omaloon-liquid-outlet.description = Permite que un solo líquido pase a través de sí mismo.
+
+block.omaloon-liquid-junction.name = Unión de Líquido
+block.omaloon-liquid-junction.description = Actúa como un puente para dos tubos de líquido que se cruzan.
+
+block.omaloon-liquid-bridge.name = Puente de Líquido
+block.omaloon-liquid-bridge.description = Transporta líquidos sobre terreno o edificios.
+
+## crafting
+block.omaloon-composite-press.name = Prensa de Compuesto
+block.omaloon-composite-press.description = Comprime Níquel y Cobalto en Compuesto.
+block.omaloon-graphite-press.name = Prensa de Grafito
+block.omaloon-graphite-press.description = Comprime carbón en grafito.
+
+## production
+block.omaloon-hammer-drill.name = Taladro de Impacto
+block.omaloon-hammer-drill.description = Cuando se coloca sobre mineral, extrae ítems. La eficiencia aumenta a medida que disminuye la presión interna, alcanzando el máximo rendimiento en valores cercanos al vacío.
+
+## power
+block.omaloon-wind-turbine.name = Turbina Eólica
+block.omaloon-wind-turbine.description = Proporciona una pequeña cantidad de energía a partir del viento.
+
+block.omaloon-coal-generator.name = Generador de Carbón
+block.omaloon-coal-generator.distribution = Genera energía quemando carbón.
+
+block.omaloon-impulse-node.name = Nodo de Impulso
+block.omaloon-impulse-node.description = Transmite energía a los edificios conectados. El nodo recibirá energía de o suministrará energía a cualquier bloque adyacente.
+
+## defense
+block.omaloon-repairer.name = Reparador
+block.omaloon-repairer.description = Cura periódicamente bloques y unidades cercanas.
+
+block.omaloon-small-shelter.name = Refugio Pequeño
+block.omaloon-small-shelter.description = Crea un campo de fuerza que protege los edificios y las unidades en su interior de los daños causados por el clima extremo.
+
+block.omaloon-composite-wall.name = Muro de Compuesto
+block.omaloon-composite-wall.description = Protege las estructuras de los proyectiles enemigos.
+block.omaloon-composite-wall-large.name = Muro de Compuesto Grande
+block.omaloon-composite-wall-large.description = Protege las estructuras de los proyectiles enemigos.
+
+## turrets
+block.omaloon-apex.name = Ápex
+block.omaloon-apex.description = Dispara balas a los enemigos.
+
+block.omaloon-convergence.name = Convergencia
+block.omaloon-convergence.description = Dispara ráfagas de balas de energía teledirigidas a los enemigos.
+
+## sandbox
+block.omaloon-pressure-source.name = Fuente de Presión
+block.omaloon-pressure-source.description = Proporciona líquidos infinitamente a la presión establecida. Solo para Sandbox.
+
+# units
+unit.omaloon-discovery.name = Descubrimiento
+unit.omaloon-discovery.description = Vehículo barato para la Cápsula de Aterrizaje. Construye estructuras.
+
+unit.omaloon-walker.name = Caminante
+unit.omaloon-walker.description = Defiende el núcleo Floe de los enemigos y construye estructuras usando drones.
+unit.omaloon-combat-drone-alpha.name = Alfa
+unit.omaloon-combat-drone-alpha.description = Dispara balas estándar a objetivos enemigos. Controlado por el Caminante.
+unit.omaloon-main-drone-mono.name = Mono
+unit.omaloon-main-drone-mono.description = Construye estructuras y extrae minerales. Controlado por el Caminante.
+
+unit.omaloon-collector.name = Colector
+unit.omaloon-collector.description = Dispara artillería que permanece en el suelo, dañando a los enemigos y curando a los aliados.
+unit.omaloon-effort.name = Effort
+unit.omaloon-effort.description = Causa daños a los objetivos en frente.
+unit.omaloon-lumen.name = Lumen
+unit.omaloon-lumen.description = Se mueve hacia los objetivos enemigos y se autodestruye, esparciendo los líquidos contenidos en su interior.
+
+unit.omaloon-legionnaire.name = Legionario
+unit.omaloon-legionnaire.description = Dispara balas estándar a objetivos enemigos.
+unit.omaloon-centurion.name = Centurión
+unit.omaloon-centurion.description = Dispara balas de metralla pequeña a objetivos enemigos.
+unit.omaloon-praetorian.name = Pretoriano
+unit.omaloon-praetorian.description = Dispara misiles balísticos de fragmentación a objetivos enemigos.
+
+unit.omaloon-cilantro.name = Cilantro
+unit.omaloon-cilantro.description = Dispara balas cargadas a objetivos enemigos.
+unit.omaloon-basil.name = Albahaca
+unit.omaloon-basil.description = Dispara un chorro continuo de llamas a objetivos enemigos.
+unit.omaloon-sage.name = Salvia
+unit.omaloon-sage.description = Dispara ráfagas de balas cargadas y artillería que permanece en el suelo.
+
+# abilities
+ability.tank = Tanque de Fluido Presurizado
+ability.omaloon-drone = Drone
+ability.omaloon-combat-drone = Drone de Combate
+ability.omaloon-utility-drone = Drone Utilitario

--- a/main/assets/bundles/bundle_es.properties
+++ b/main/assets/bundles/bundle_es.properties
@@ -1,16 +1,10 @@
 ## ui
 dialog.omaloon-disclaimer.title = AVISO
-dialog.omaloon-disclaimer = \
-  Omaloon aún se encuentra en desarrollo [accent]alfa[] y puede contener algunos errores.\
-  \nEl contenido presentado aquí no es final y puede estar sujeto a cambios radicales en futuras versiones.\
-  \nNo te encariñes con tus partidas guardadas con Omaloon activado, ya que cada nueva versión las borrará.
+dialog.omaloon-disclaimer = Omaloon aún se encuentra en desarrollo [accent]alfa[] y puede contener algunos errores.\nEl contenido presentado aquí no es final y puede estar sujeto a cambios radicales en futuras versiones.\nNo te encariñes con tus partidas guardadas con Omaloon activado, ya que cada nueva versión las borrará.
 button.omaloon-show-disclaimer = No volver a mostrar
 
 dialog.omaloon-updater.title = ¡Nueva versión de Omaloon encontrada!
-dialog.omaloon-updater = \
-  Lo más probable es que Omaloon haya recibido una actualización de contenido o una corrección de errores. Se recomienda instalar la actualización.\
-  \n[red]¡Todas tus partidas con Omaloon activado se borrarán después de actualizar![]\
-  \n\n[gray]La versión actual de Omaloon es v{0}, pero la última es v{1}.[]
+dialog.omaloon-updater = Lo más probable es que Omaloon haya recibido una actualización de contenido o una corrección de errores. Se recomienda instalar la actualización.\n[red]¡Todas tus partidas con Omaloon activado se borrarán después de actualizar![]\n\n[gray]La versión actual de Omaloon es v{0}, pero la última es v{1}.[]
 button.omaloon-ignore = Ignorar
 button.omaloon-updater-show-changes = Lista de Cambios
 button.omaloon-install-update = ¿Instalar y reiniciar ahora?
@@ -35,12 +29,12 @@ setting.omaloon-reset-hints = Restablecer Consejos del Mod
 setting.omaloon-discord-join.name = ¡Únete al servidor de Discord de Omaloon!
 
 ## Hints
-hint.omaloon-air = A diferencia del \uEAB2 [accent]Tubo de Fluido[], ciertos bloques con mayor capacidad pueden almacenar más fluido a la misma presión.
-hint.omaloon-drills = Los bloques que utilizan presión alcanzan su máxima eficiencia en valores extremos. El \uEAA8 [accent]Taladro de Impacto[] destaca en condiciones cercanas al vacío, mientras que otros bloques pueden requerir alta presión.
+hint.omaloon-air = A diferencia del \ueab2 [accent]Tubo de Fluido[], ciertos bloques con mayor capacidad pueden almacenar más fluido a la misma presión.
+hint.omaloon-drills = Los bloques que utilizan presión alcanzan su máxima eficiencia en valores extremos. El \ueaa8 [accent]Taladro de Impacto[] destaca en condiciones cercanas al vacío, mientras que otros bloques pueden requerir alta presión.
 hint.omaloon-pump_chaining = Las bombas pueden apilarse en serie o en paralelo. Lo primero permite mayor fuerza, lo segundo permite mayor eficiencia.
-hint.omaloon-wind_turbines = Las \uEAAB [accent]Turbinas Eólicas[] generan una fuerte turbulencia, dañándose entre sí si se colocan demasiado cerca. Para evitar su destrucción, la colocación está restringida a una distancia segura.
-hint.omaloon-press = Algunos bloques, como la \uEAAD [accent]Prensa de Compuesto[], no intercambian fluido con los vecinos, interactuando solo con bloques de transporte como el \uEAB2 [accent]Tubo de Fluido[].
-hint.omaloon-shelter = El \uEAA6 [accent]Refugio Pequeño[] utiliza presión positiva, extendiendo su rango efectivo a medida que aumenta la presión.
+hint.omaloon-wind_turbines = Las \ueaab [accent]Turbinas Eólicas[] generan una fuerte turbulencia, dañándose entre sí si se colocan demasiado cerca. Para evitar su destrucción, la colocación está restringida a una distancia segura.
+hint.omaloon-press = Algunos bloques, como la \ueaad [accent]Prensa de Compuesto[], no intercambian fluido con los vecinos, interactuando solo con bloques de transporte como el \ueab2 [accent]Tubo de Fluido[].
+hint.omaloon-shelter = El \ueaa6 [accent]Refugio Pequeño[] utiliza presión positiva, extendiendo su rango efectivo a medida que aumenta la presión.
 
 ## Sector
 


### PR DESCRIPTION
added the Spanish translation file to the project. I followed the standard Mindustry terminology to ensure the names of buildings and items remain consistent with the base game. This should help expand the mod's reach to the Spanish-speaking community.