### PR TITLE
Fix liquid color flickering in conduits

### DIFF
--- a/main/src/omaloon/world/modules/PressureModule.java
+++ b/main/src/omaloon/world/modules/PressureModule.java
@@ -28,9 +28,11 @@ public class PressureModule extends BlockModule{
     public @Nullable Liquid getMain(){
         if(!cacheDirty) return mainCache;
 
-        float val = 0;
-        int out = -1;
+        int out = mainCache == null ? -1 : mainCache.id;
+        float val = out == -1 ? 0 : getAmount(out) * 1.05f;
+
         for(int i = -1; i < liquids.length - 1; i++){
+            if(i == out) continue;
             float amount = getAmount(i);
             if(amount > val && !Mathf.zero(amount)){
                 val = amount;


### PR DESCRIPTION
This PR addresses the issue where liquid colors would flicker rapidly when multiple fluids are present in equal amounts. I implemented a hysteresis factor in the fluid selection logic by giving the current dominant liquid a 5% stability bias. This prevents the renderer from constantly jumping between colors due to minor floatingpoint fluctuations. Please note that I was unable to effectively replicate the original bug on my local environment, so I ask the reviewer to carefully validate this fix to ensure it resolves the visual glitch as intended before merging